### PR TITLE
Add Agent Brain to Standalone Libraries section

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ A curated list of projects on **memory systems of AI agents**.
 
 * **[O-Mem](https://github.com/OPPO-PersonalAI/O-Mem)** – *Omni memory system for personalized, long‑horizon, self‑evolving agents.* It views memory as an active user‑modelling process: it continually extracts and updates **user persona attributes**, **event records**, and **topic‑indexed messages**.  This enables **dynamic user profiling**, a **three‑layer hierarchical memory** (persona, event and message), **user‑centric retrieval**, and **interaction‑time scaling**.  O‑Mem includes an evaluation suite and exposes modular APIs under the Apache‑2.0 license.
 
+* **[Agent Brain](https://github.com/kaderosio/agent-brain)** – **7-layer cognitive memory** system for AI agents with **perception gate**, **dream cycle** for offline consolidation, and **predictive memory** engine. Built with FastAPI, PostgreSQL/pgvector, sentence-transformers, and spaCy. Self-hostable via Docker, no LLM required.
+
 * **[OpenMemory Engine](https://github.com/CaviraOSS/OpenMemory)** – Self-hosted, **sectorized semantic memory engine** with hierarchical storage, **auto decay**, and **explainable recall graphs**; integrates with LangGraph, Mem0, and MCP tools.
 
 * **[Task Memory Engine](https://github.com/biubiutomato/TME-Agent)** – Structured **task-level memory engine** combining **hierarchical trees** and **rollback-aware buffers** to track multi-step reasoning; enables **state reconstruction and planning** with minimal context tokens. 


### PR DESCRIPTION
Adds [Agent Brain](https://github.com/kaderosio/agent-brain) to the Standalone Libraries / Frameworks section.

Agent Brain is an open-source 7-layer cognitive memory system for AI agents with perception gate, dream cycle, and predictive capabilities. Built with FastAPI, PostgreSQL/pgvector, sentence-transformers, and spaCy. Self-hostable via Docker, no LLM required.