### PR TITLE
docs: add MemClaw to MCP-Centric Memory Servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ A curated list of projects on **memory systems of AI agents**.
 
 * **[Redis Agent Memory Server](https://github.com/redis/agent-memory-server)** – Redis-powered memory with **REST + MCP**, **two-tier memory** (session/long-term), configurable extraction, and pluggable vector backends.
 
+* **[MemClaw](https://github.com/Felo-Inc/memclaw)** – **Project-isolated MCP memory** for AI coding agents; creates a separate memory workspace per project with a **web dashboard** for reviewing and managing what your AI remembers. Free to use, MIT licensed. ([Site](https://memclaw.me))
+
 ## Contributing
 
 Contributions are welcome! If a project belongs here, open an issue or PR with:


### PR DESCRIPTION
## Summary

- Adds MemClaw to the MCP-Centric Memory Servers & Tools section

## About MemClaw

- **Project-isolated MCP memory** for AI coding agents
- Each project gets a separate memory workspace, preventing context bleed between codebases
- **Web dashboard** for reviewing and managing what your AI remembers
- MCP-compatible, works with Claude Code, Cursor, Gemini CLI, and Codex
- Free to use, MIT licensed

- GitHub: https://github.com/Felo-Inc/memclaw
- Website: https://memclaw.me

## Testing

- [x] Links verified and accessible
- [x] Follows existing entry style (bold name, en-dash, bold keywords, italic features)
- [x] Placed in MCP-Centric section (correct category)