### PR TITLE
Add AccInt to MCP memory tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ A curated list of projects on **memory systems of AI agents**.
 
 ## MCP-Centric Memory Servers & Tools
 
+* **[AccInt](https://github.com/maxbaluev/accreted-intelligence)** – Local-first **Work Model + MCP server** for coding-agent memory across Claude Code, OpenCode, Codex, and Cursor. Uses a **SQLite-backed** memory substrate with `acc_retrieve`/`acc_act` tools and feeds verified outcomes back into future retrieval. [Homepage](https://accint.xyz/). Public integration glue with private engine.
+
 * **[Basic Memory](https://github.com/basicmachines-co/basic-memory)** – **Local-first Markdown** knowledge base exposed via MCP; bi-directional human/LLM editing with simple, file-backed persistence.
 
 * **[OpenMemory MCP](https://mem0.dev/openmemory)** – Mem0’s **local-only** MCP server that centralizes cross-tool memory with a unified dashboard.


### PR DESCRIPTION
## Summary

Adds AccInt to the MCP-Centric Memory Servers & Tools section.

AccInt is a local-first Work Model and MCP server for coding-agent memory across Claude Code, OpenCode, Codex, and Cursor. It exposes `acc_retrieve` / `acc_act` over a SQLite-backed memory substrate and feeds verified outcomes back into future retrieval.

## Contribution details

- **License / boundary**: public integration glue with private engine; the entry says this explicitly.
- **Ecosystem**: MCP, Claude Code, OpenCode, Codex, Cursor.
- **Unique feature**: outcome-graded retrieval loop for coding-agent memory, with local-first SQLite persistence.

## Validation

- `git diff --check`
- Checked `https://accint.xyz/` and `https://github.com/maxbaluev/accreted-intelligence` return HTTP 200
