### PR TITLE
Add Agentage Memory (remote MCP server)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ A curated list of projects on **memory systems of AI agents**.
 
 ## MCP-Centric Memory Servers & Tools
 
-* **[agentage Memory](https://memory.agentage.io)** – *One memory. Every AI. Owned by you.* A **remote, hosted MCP server** (Streamable HTTP at `https://memory.agentage.io/mcp`) that gives every AI client one shared memory: a **git-backed Markdown store you own** (mirrored locally as plain `.md`, exportable anytime) searched with `git grep`. Cross-vendor across Claude / Cursor / ChatGPT via 6 tools (`memory__search/read/write/edit/list/delete`). Secured with **OAuth 2.1 + PKCE + Dynamic Client Registration**. Registry: `io.agentage/memory`.
+* **[Agentage Memory](https://memory.agentage.io)** – *One memory. Every AI. Owned by you.* A **remote, hosted MCP server** (Streamable HTTP at `https://memory.agentage.io/mcp`) that gives every AI client one shared memory: a **git-backed Markdown store you own** (mirrored locally as plain `.md`, exportable anytime) searched with `git grep`. Cross-vendor across Claude / Cursor / ChatGPT via 6 tools (`memory__search/read/write/edit/list/delete`). Secured with **OAuth 2.1 + PKCE + Dynamic Client Registration**. Registry: `io.agentage/memory`.
 
 * **[Basic Memory](https://github.com/basicmachines-co/basic-memory)** – **Local-first Markdown** knowledge base exposed via MCP; bi-directional human/LLM editing with simple, file-backed persistence.
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ A curated list of projects on **memory systems of AI agents**.
 
 ## MCP-Centric Memory Servers & Tools
 
+* **[agentage Memory](https://memory.agentage.io)** – *One memory. Every AI. Owned by you.* A **remote, hosted MCP server** (Streamable HTTP at `https://memory.agentage.io/mcp`) that gives every AI client one shared memory: a **git-backed Markdown store you own** (mirrored locally as plain `.md`, exportable anytime) searched with `git grep`. Cross-vendor across Claude / Cursor / ChatGPT via 6 tools (`memory__search/read/write/edit/list/delete`). Secured with **OAuth 2.1 + PKCE + Dynamic Client Registration**. Registry: `io.agentage/memory`.
+
 * **[Basic Memory](https://github.com/basicmachines-co/basic-memory)** – **Local-first Markdown** knowledge base exposed via MCP; bi-directional human/LLM editing with simple, file-backed persistence.
 
 * **[OpenMemory MCP](https://mem0.dev/openmemory)** – Mem0’s **local-only** MCP server that centralizes cross-tool memory with a unified dashboard.


### PR DESCRIPTION
Adds **Agentage Memory**, a remote MCP server (Streamable HTTP) that gives every AI tool one shared markdown memory you own.

- **Endpoint:** `https://memory.agentage.io/mcp`
- **Auth:** OAuth 2.1 + PKCE + Dynamic Client Registration (no API key)
- **Website:** https://agentage.io
- **Documentation:** https://agentage.io/blog/mcp-endpoint-is-live
- **Official MCP registry:** `io.agentage/memory`

**Tools (6):** `memory__search`, `memory__read`, `memory__write`, `memory__edit`, `memory__list`, `memory__delete` — one markdown memory that Claude, Cursor, and ChatGPT all read and write, mirrored locally as plain `.md` you can export anytime.

Happy to adjust placement/format to match this list's conventions.
