### PR TITLE
Add LWC source-grounded agent memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ A curated list of projects on **memory systems of AI agents**.
 
 * **[Persistent AI Memory System](https://github.com/Savantskie/persistent-ai-memory)** – Persistent, searchable memory plus **tool-usage logs**, deduping/self-reflection, and cross-conversation sync.
 
+* **[LWC](https://github.com/JanYork/llm-wiki-cli)** – Agent-driven proactive project memory that compiles selected sources into a durable **SQLite-backed Wiki** with citations, provenance, FTS5 retrieval, atomic changesets, and optional document/code graphs. A single bounded read-only **MCP** tool plus native Skills and lifecycle Hooks integrates the same memory across supported coding-agent hosts.
+
 ## Memory Modules in Existing Agent Frameworks
 
 * **[Ars Contexta](https://github.com/agenticnotetaking/arscontexta)** – A **second brain** for your agent. A **Claude Code plugin** that generates complete knowledge systems from conversation — you describe how you think and work, and the engine derives a **cognitive architecture** (folder structure, context files, processing pipeline, hooks, navigation maps, and note templates) tailored to your domain and backed by **249 research claims**. No templates, no configuration — just conversation.


### PR DESCRIPTION
## Summary

Add LWC to **Standalone Libraries / Frameworks for Building Agent Memory Systems**.

## Project details

- **Name:** LWC
- **Repository:** https://github.com/JanYork/llm-wiki-cli
- **Storage:** SQLite-backed Wiki with FTS5; optional physical document graph and CodeGraph projections
- **Retrieval:** lexical/structured scoped retrieval through CLI and one bounded read-only MCP tool
- **Unique highlight:** source-grounded memory with immutable source snapshots, citations, provenance, freshness tracking, revision history, and atomic changesets
- **Ecosystem:** multiple coding-agent hosts through MCP, Skills, Hooks, and additive instructions
- **License:** Apache-2.0

## Validation

- [x] Repository URL returns HTTP 200
- [x] No duplicate LWC entry
- [x] One concise project description with a distinctive architecture highlight
- [x] `git diff --check`
