### PR TITLE
Add RCLL (fleet-memory) to MCP-Centric Memory Servers & Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ A curated list of projects on **memory systems of AI agents**.
 * **[MCP-Titan](https://github.com/henryhawke/mcp-titan)** – Experimental **neural memory engine** integrating **online vector processing** and **TensorFlow.js learning loops**, enabling live memory update and auto-retention control. 
 
 
+* **[RCLL (fleet-memory)](https://github.com/holetron-lab/fleet-memory)** – Self-hosted **shared** memory for a *team* of agents rather than for one: facts are scoped by topic **room**, typed by hall and tiered **L0–L3** over **Postgres + pgvector**. The **read path never invokes a language model**, so a recall costs CPU and zero model tokens; the project publishes its own ablation of what one pooled store costs against ten private ones. MIT, MCP over stdio, fork of [Hindsight](https://github.com/vectorize-io/hindsight).
+
 * **[Redis Agent Memory Server](https://github.com/redis/agent-memory-server)** – Redis-powered memory with **REST + MCP**, **two-tier memory** (session/long-term), configurable extraction, and pluggable vector backends.
 
 ## Contributing


### PR DESCRIPTION
Adds RCLL (`fleet-memory`) under **MCP-Centric Memory Servers & Tools**. One line added, nothing else touched.

* **Name + link:** RCLL (`fleet-memory`) — https://github.com/holetron-lab/fleet-memory
* **Description:** self-hosted shared memory for a *team* of agents rather than for one — facts are scoped by topic **room**, typed by hall and tiered **L0–L3** over Postgres + pgvector.
* **Unique feature:** the read path never invokes a language model, so a recall costs CPU and zero model tokens. We also publish our own ablation of what one *pooled* store costs against ten private ones (LoCoMo, a competitor's harness, paired CIs) — including the arms where pooling loses: https://rcll.ai/docs/benchmarks/
* **License / ecosystem:** MIT; MCP over stdio; fork of [`vectorize-io/hindsight`](https://github.com/vectorize-io/hindsight) (MIT), which is already listed here — this is a fork with a different scoping model, and the entry says so rather than presenting itself as unrelated work.

The entry deliberately carries no install command: the npm name is currently held by a deprecated `0.0.0` placeholder published only to enable trusted publishing, and the first real release is not out yet.